### PR TITLE
Remove trailing comma to support PHP 7.2

### DIFF
--- a/includes/admin/settings/class-advanced.php
+++ b/includes/admin/settings/class-advanced.php
@@ -63,7 +63,7 @@ class CAOS_Admin_Settings_Advanced extends CAOS_Admin_Settings_Builder {
 			__( 'Compatibility Mode', 'host-analyticsjs-local' ),
 			CAOS_Admin_Settings::CAOS_ADV_SETTING_COMPATIBILITY_MODE,
 			CAOS::get( CAOS_Admin_Settings::CAOS_ADV_SETTING_COMPATIBILITY_MODE, '' ) != '' ? 'on' : '',
-			__( 'Check this option to use CAOS with any other Google Analytics plugin. Any reference to <code>googletagmanager.com/gtag/js</code> in your site\'s HTML will be replaced with the URL pointing to the local copy. <strong>Warning!</strong> Please make sure that CAOS\' <strong>Basic Settings</strong> match your Google Analytics plugin\'s configuration.', 'host-analyticsjs-local' ),
+			__( 'Check this option to use CAOS with any other Google Analytics plugin. Any reference to <code>googletagmanager.com/gtag/js</code> in your site\'s HTML will be replaced with the URL pointing to the local copy. <strong>Warning!</strong> Please make sure that CAOS\' <strong>Basic Settings</strong> match your Google Analytics plugin\'s configuration.', 'host-analyticsjs-local' )
 		);
 	}
 


### PR DESCRIPTION
PHP versions before 7.3 do not support trailing comma. This causes wp-admin to crash on PHP 7.2 or older. 

This function seems to be the only place where trailing comma is used. I tested this manually on my server where I still have 7.2.